### PR TITLE
Encode username and password in percent-encoding format

### DIFF
--- a/src/nodejs/amqp.ts
+++ b/src/nodejs/amqp.ts
@@ -4,6 +4,7 @@ const fs = require("fs");
 const getos = require("getos");
 const util = require("util");
 const getOsPromise = util.promisify(getos);
+import * as querystring from 'querystring';
 
 var osDistroLowerCase;
 const defaultCaFileLocation = "/etc/ssl/certs/ca-certificates.crt";
@@ -272,7 +273,7 @@ function AmqpAck(n) {
         var urlType = node.useTls ? "amqps://" : "amqp://";
         var credentials = "";
         if (node.credentials.user) {
-          credentials = node.credentials.user + ":" + node.credentials.password + "@";
+          credentials = querystring.escape(node.credentials.user) + ":" + querystring.escape(node.credentials.password) + "@";
         }
         var urlLocation = node.host + ":" + node.port;
         if (node.vhost) {


### PR DESCRIPTION
**The Issue**
If the username or password contains any special character, the connection to RabbitMQ server would fail.

According to the [amqplib document](https://www.squaremobius.net/amqp.node/channel_api.html#auth), usernames and passwords should be [percent-encoded](https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding).

**The Workaround**
You can use existing online tool such as [urlencoder](https://www.urlencoder.org/) to manually convert username or password to percent-encoded format while setting the connection parameters.

**The PR**
This PR uses [escape()](https://nodejs.org/docs/latest-v12.x/api/querystring.html#querystring_querystring_escape_str) method to encode username and password into amqplib expected format.
It is a simple change, but please test before merge.

@ElGranLoky 
Thanks for the module.
Can you please improve the [Fast developer section](https://github.com/ElGranLoky/node-red-contrib-amqp-ack#fast-developer-) in Readme? I find it is hard to follow and I have no way to properly compile and test the PR above.

Thanks again!